### PR TITLE
Handle require statements that end with .js

### DIFF
--- a/index.es
+++ b/index.es
@@ -24,7 +24,8 @@ function inliner(fpath, callback) {
         while ((match = re.exec(_data)) !== null) {
 
             const [requireDeclaration, relativePath] = match
-            const dpath = `${path.resolve(path.resolve(path.dirname(fpath)), relativePath)}.js`
+            const dpath = `${path.resolve(path.resolve(path.dirname(fpath)), relativePath)}`
+            if (!dpath.endsWith('.js')) { dpath += '.js' }
             const required = require(dpath)
             const dependency = typeof required === 'function' ? String(required) : JSON.stringify(required)
 


### PR DESCRIPTION
Currently the project only handles code like this: 
const dep = `require('./dependency');`
This change allows the require statement above as well as ones like this:
const dep = `require('./dependency.js');`